### PR TITLE
📖 일기 상세 페이지 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './pages/home/HomePage';  // 경로 수정
 import SuccessPage from './pages/success/SuccessPage'; // 성공 페이지 경로도 확인
 import EditorPage from './pages/diary/diaryEditor/DiaryEditorPage.tsx';
+import DiaryDetailPage from "./pages/diary/diaryDetail/DiaryDetailPage.tsx";
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/success" element={<SuccessPage />} />
         <Route path="/editor" element={<EditorPage />} />
+        <Route path="/detail" element={<DiaryDetailPage />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/diary/diaryDetail/DiaryDetailPage.css
+++ b/client/src/pages/diary/diaryDetail/DiaryDetailPage.css
@@ -1,0 +1,117 @@
+.container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 32px 24px;
+    box-sizing: border-box;
+    position: relative;
+}
+
+.backButton {
+    position: absolute;
+    top: 5px;
+    left: 24px;
+    font-size: 20px;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.title {
+    font-size: 28px;
+    font-weight: bold;
+    margin: 40px 0 8px 0; /* 위쪽 간격 추가 */
+    text-align: left;
+}
+
+.date {
+    color: #999;
+    font-size: 15px;
+    margin-top: 10px; /* 추가 */
+    margin-bottom: 10px;
+    text-align: left;
+}
+
+.editorWrapper {
+    background-color: #f0f0f0;
+    border-radius: 8px;
+    padding: 16px;
+    width: 100%;
+    height: 540px; /* 고정 높이 */
+    box-sizing: border-box;
+}
+
+/* 에디터를 감싸는 div 스타일 */
+.editor-container {
+    width: 100%;
+    height: 500px;
+    margin: 0 auto;
+    border: 2px solid #eb1c24;
+    border-radius: 8px;
+    padding: 20px 60px 20px 60px;
+    box-sizing: border-box;
+    font-size: 20px;
+    overflow-y: auto;
+    display: flex;
+    justify-content: flex-start;
+}
+
+/* 전체 블록의 중앙 정렬 해제 */
+.editor-container .ce-block,
+.editor-container .cdx-block {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    box-sizing: border-box;
+}
+
+/* 에디터 내부 텍스트 블록을 반응형으로 */
+.editor-container .ce-paragraph {
+    width: 1100px !important;
+    max-width: 1100px !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    box-sizing: border-box;
+    text-align: left !important;
+}
+
+.selected-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 10px;
+    margin-top: 20px;
+}
+
+.tag {
+    background-color: #ffecec;
+    color: #eb1c24;
+    padding: 10px 20px;
+    border-radius: 25px;
+    font-size: 16px;
+    font-weight: 500;
+    border: 1.5px solid #eb1c24;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.tag:hover {
+    background-color: #eb1c24;
+    color: white;
+}
+
+
+/* 반응형 추가 */
+@media (max-width: 768px) {
+    .container {
+        padding: 24px 16px;
+    }
+
+    .title {
+        font-size: 22px;
+    }
+
+    .editorWrapper {
+        min-height: 300px;
+    }
+}

--- a/client/src/pages/diary/diaryDetail/DiaryDetailPage.tsx
+++ b/client/src/pages/diary/diaryDetail/DiaryDetailPage.tsx
@@ -1,0 +1,69 @@
+import React, {useEffect, useRef, useState} from 'react';
+import './DiaryDetailPage.css';
+import {destroyEditor, initializeViewer} from "./DiaryDetailView.ts";
+import {DiaryInfoDto} from "./DiaryInfoDto.ts";
+
+const DiaryDetailPage: React.FC = () => {
+    const viewerContainerRef = useRef<HTMLDivElement | null>(null);
+    const [diaryData, setDiaryData] = useState<DiaryInfoDto | null>(null);
+
+    // 날짜 포맷팅 함수
+    const formatDate = (dateString: string) => {
+        const date = new Date(dateString);  // ISO 형식의 문자열을 Date 객체로 변환
+        const dayOfWeek = date.toLocaleString('ko-KR', { weekday: 'short' });
+        const day = date.getDate();
+        const month = date.getMonth() + 1; // 월 (0부터 시작하므로 +1)
+        const year = date.getFullYear();
+
+        return `${year}.${month}.${day} (${dayOfWeek})`;
+    };
+
+    useEffect(() => {
+        const fetchAndInit = async () => {
+            if (!viewerContainerRef.current) return;
+
+            try {
+                const res = await fetch('http://localhost:8080/diary/1'); // diary id: 1로 고정(임시)
+                const data: DiaryInfoDto = await res.json();
+                const savedJson = JSON.parse(data.content);
+
+                console.log("받아온 일기 데이터:", savedJson); // 콘솔 출력
+
+                initializeViewer(viewerContainerRef.current, savedJson);
+                setDiaryData(data);
+            } catch (error) {
+                console.error('데이터 로딩 및 뷰어 초기화 실패:', error);
+            }
+        };
+
+        fetchAndInit();
+
+        return () => {
+            destroyEditor();
+        };
+    }, []);
+
+    return (
+        <div className="container">
+            <button className="backButton">{'←'}</button>
+
+            <h1 className="title">{diaryData?.title || 'Loading...'}</h1>
+            <p className="date">{diaryData?.date ? formatDate(diaryData.date) : 'Loading...'}</p>
+
+            <div className="editorWrapper">
+                <div
+                    className="viewer-container"
+                    ref={viewerContainerRef}
+                ></div>
+            </div>
+
+            <div className="selected-tags">
+                {diaryData?.tags.map((tag, index) => (
+                    <div key={index} className="tag">#{tag}</div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default DiaryDetailPage;

--- a/client/src/pages/diary/diaryDetail/DiaryDetailView.ts
+++ b/client/src/pages/diary/diaryDetail/DiaryDetailView.ts
@@ -1,0 +1,80 @@
+import EditorJS from '@editorjs/editorjs';
+import Header from '@editorjs/header';
+import List from '@editorjs/list';
+import Image from '@editorjs/image';
+
+export let editor: EditorJS | null = null; // 에디터 인스턴스 (전역 참조용)
+let isInitializing = false; // 중복 초기화를 방지하기 위한 플래그
+
+// 에디터 초기화
+export const initializeViewer = (holder: HTMLElement, savedJson: any) => {
+    if (editor || isInitializing) return;
+
+    console.log("tsx에서 받아온 데이터:", savedJson); // 디버깅용
+
+    console.log("initializing...");
+    isInitializing = true;
+
+    const instance = new EditorJS({
+        holder,
+        readOnly: true, // 읽기 전용 모드 설정
+        tools: {
+            header: Header,
+            list: List,
+            image: {
+                class: Image,
+                config: {
+                    uploader: {
+                        uploadByFile(file: File) {
+                            // 클라이언트 측에서만 처리
+                            return new Promise((resolve) => {
+                                const reader = new FileReader();
+
+                                reader.onload = () => {
+                                    resolve({
+                                        success: 1,
+                                        file: {
+                                            url: reader.result,  // Data URL로 파일을 반환
+                                        },
+                                    });
+                                };
+
+                                // 파일을 읽고 Data URL 형식으로 저장
+                                reader.readAsDataURL(file);
+                            });
+                        }
+                    }
+                }
+            },
+        },
+        autofocus: true,
+    });
+
+    instance.isReady.then(() => {
+        editor = instance;
+
+        // 에디터가 초기화된 후, savedJson이 있으면 렌더링
+        if (savedJson) {
+            editor.render(savedJson).then(() => {
+                console.log("Viewer data rendered successfully");
+            }).catch((error) => {
+                console.error("Rendering data failed:", error);
+            });
+        }
+
+        isInitializing = false;
+        console.log("Viewer initialized!");
+    }).catch((error) => {
+        console.error("Viewer init failed", error);
+        isInitializing = false;
+    });
+};
+
+// 에디터 제거(메모리 해제)
+export const destroyEditor = () => {
+    if (editor && typeof editor.destroy === 'function') {
+        editor.destroy();
+        editor = null;
+        console.log("Viewer destroyed");
+    }
+};

--- a/client/src/pages/diary/diaryDetail/DiaryInfoDto.ts
+++ b/client/src/pages/diary/diaryDetail/DiaryInfoDto.ts
@@ -1,0 +1,7 @@
+export interface DiaryInfoDto {
+    diaryId: number;
+    title: string;
+    content: any; // Editor.js의 saved JSON 형태 (object)
+    date: string;
+    tags: string[];
+}

--- a/client/src/pages/diary/diaryEditor/DiaryEditorPage.css
+++ b/client/src/pages/diary/diaryEditor/DiaryEditorPage.css
@@ -38,7 +38,7 @@ html, body, #root {
 }
 
 .title {
-    font-size: 24px;
+    font-size: 24px  !important;
     font-weight: bold;
     margin-top: 10px !important;
     margin-bottom: 8px;
@@ -162,7 +162,7 @@ html, body, #root {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 20px !important;
     margin-top: 0px !important;
 }
 
@@ -195,7 +195,8 @@ html, body, #root {
     font-size: 15px;
     border-radius: 20px;
     border: 2px solid #eb1c24;
-    background-color: white;
+    //background-color: white;
+    background-color: #ffecec;
     color: #eb1c24;
     cursor: pointer;
     transition: all 0.2s;


### PR DESCRIPTION
## 📝 작업 내용

### `DiaryDetailView.ts` 추가
- `initializeViewer`: EditorJS 인스턴스를 초기화하고, 주어진 JSON 데이터를 읽어 렌더링
  - 에디터를 읽기 전용 모드로 설정
  - 이미지 업로더 설정: 클라이언트 측에서 데이터 URL로 이미지를 처리
  - 중복 초기화를 방지하는 플래그 추가
- `destroyEditor`: 에디터 인스턴스를 제거하여 메모리 해제
  - `editor.destroy()` 메서드를 호출하여 에디터 인스턴스를 삭제하고, 메모리 해제

### `DiaryDetailPage.tsx`, `DiaryDetailPage.css` 추가 
- 일기 제목, 날짜, 태그 및 에디터 콘텐츠 표시
- fetch로 `http://localhost:8080/diary/{diaryId}` API에서 일기 데이터 받아오기 (현재는 `diaryId = 1`로 고정)
- `initializeViewer`로 Editor.js 뷰어 초기화
- `formatDate` 함수로 날짜 포맷팅
- `destroyEditor`로 컴포넌트 언마운트 시 에디터 정리
- 태그 표시 기능 추가

### `DiaryInfoDto.ts` 추가
- 일기 정보 관리용 `DiaryInfoDto` 인터페이스 추가

### 일기 상세 페이지 라우팅 추가
- detail 경로에 `DiaryDetailPage` 컴포넌트 연결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
**일기 불러오기 성공**
![image](https://github.com/user-attachments/assets/79a723ea-eb29-4ead-97d0-385cf8cc81d4)
![image](https://github.com/user-attachments/assets/5832507d-d6a5-48bd-b682-03a592a70dc3)


## 💬 공유사항 to 리뷰어
- UI 배치 괜찮은지... 뒤로가기 버튼은 나중에 위치 조정 예정
- 태그까지 로드되는지 확인

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).