### PR TITLE
일기 제목 수정 기능 추가 및 Authorization 헤더에 access token 포함

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import SuccessPage from './pages/success/SuccessPage';
 import ListPage from './pages/diary/list/ListPage';
 import SettingPage from './pages/setting/MailSettingPage';
 import EditorPage from './pages/diary/diaryEditor/DiaryEditorPage';
+import DiaryDetailPage from './pages/diary/diaryDetail/DiaryDetailPage';
 
 function App() {
   return (
@@ -14,7 +15,7 @@ function App() {
         <Route path="/success" element={<SuccessPage />} />
         <Route path="/list" element={<ListPage />} />
         <Route path="/setting" element={<SettingPage />} />
-        <Route path="/editor" element={<EditorPage />} />
+        <Route path="/editor/:questionText" element={<EditorPage />} />
         <Route path="/detail" element={<DiaryDetailPage />} />
       </Routes>
     </Router>

--- a/client/src/pages/diary/diaryEditor/DiaryEditorPage.css
+++ b/client/src/pages/diary/diaryEditor/DiaryEditorPage.css
@@ -5,11 +5,29 @@
     box-sizing: border-box;
 }
 
-html, body, #root {
+/*html, body, #root {*/
+/*    height: 100%;*/
+/*    width: 100%;*/
+/*    overflow-y: auto;*/
+/*    overflow-x: hidden;*/
+/*}*/
+
+/* #root 영역에서 스크롤 제어 */
+#root {
+    position: relative;  /* 자식 요소가 잘 보이도록 설정 */
     height: 100%;
     width: 100%;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: hidden;  /* 가로 스크롤바 숨김 */
+    overflow-y: auto;    /* 세로 스크롤바 필요 시 표시 */
+}
+
+/* body와 html의 설정 */
+html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;    /* 불필요한 스크롤바 숨김 */
 }
 
 /* 전체 페이지 */
@@ -32,16 +50,57 @@ html, body, #root {
     width: 100%;
 }
 
+/* 헤더 */
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #eb1c24;
+    padding: 15px 30px;
+    color: white;
+    width: 100%;
+}
+
+.logo {
+    font-size: 20px;
+    font-weight: bold;
+    color: white;
+}
+
+.nav a {
+    margin-left: 20px;
+    text-decoration: none;
+    color: white;
+    font-size: 14px;
+}
+
 /* 제목 */
 .title-block {
     margin-bottom: 20px;
 }
 
 .title {
-    font-size: 24px  !important;
+    font-size: 24px !important;
     font-weight: bold;
     margin-top: 10px !important;
     margin-bottom: 8px;
+    line-height: 1.2; /* 제목의 라인 높이 */
+}
+
+.title-input {
+    font-size: 24px;
+    font-weight: bold;
+    border: none;
+    border-bottom: 1px solid #ccc;
+    outline: none;
+    width: 100%;
+    margin-top: 10px !important;
+    margin-bottom: 8px !important;
+    padding: 5px 0; /* 위아래 패딩 조정 */
+    height: 32px; /* 높이를 명시적으로 맞춤 */
+    line-height: 1.2; /* 제목과 입력 필드의 라인 높이 맞추기 */
+    box-sizing: border-box; /* padding 포함 크기 */
+    vertical-align: middle; /* 수직 정렬 */
 }
 
 .date {
@@ -66,7 +125,7 @@ html, body, #root {
 /* 에디터를 감싸는 div 스타일 */
 .editor-container {
     width: 100%;
-    height: 500px;
+    height: 450px !important;
     margin: 0 auto;
     border: 2px solid #eb1c24;
     border-radius: 8px;
@@ -97,10 +156,11 @@ html, body, #root {
     text-align: left !important;
 }
 
-/* 버튼 */
+/* 버튼 관련 스타일 */
 .button-wrapper {
+    position: relative;  /* 버튼이 보일 수 있도록 설정 */
     text-align: right;
-    margin-top: auto;
+    /*margin-top: 0px;  !* 여기에서 'auto' 대신 숫자 값으로 마진을 설정 *!*/
 }
 
 .submit-button {
@@ -155,7 +215,7 @@ html, body, #root {
 /* 태그 */
 .tag-section {
     margin-top: 10px;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
 }
 
 .selected-tags {

--- a/client/src/pages/diary/diaryEditor/DiaryEditorPage.tsx
+++ b/client/src/pages/diary/diaryEditor/DiaryEditorPage.tsx
@@ -18,15 +18,13 @@ export const DiaryEditorPage: React.FC = () => {
     const [isAddingTag, setIsAddingTag] = useState(false); // + 버튼 클릭 여부
     const [newTagName, setNewTagName] = useState(""); // 입력 중인 태그 이름
 
-    // URL에서 받아온 질문 제목을 useState로 초기화
-    const { questionText } = useParams<{ questionText: string }>();
-
-    const [isEditingTitle, setIsEditingTitle] = useState(false);
-    // 초기값을 URL에서 받은 타이틀로 설정
-    const [title, setTitle] = useState(questionText || "📬 오늘 가장 인상 깊었던 순간은?");
-
-
     const formattedDate = getFormattedToday(); // 오늘 날짜 포맷팅
+
+    const { questionText } = useParams<{ questionText: string }>(); // URL에서 받아온 질문 제목을 useState로 초기화
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const [title, setTitle] = useState(questionText || "📬 오늘 가장 인상 깊었던 순간은?");  // 초기값을 URL에서 받은 타이틀로 설정
+
+    const accessToken = localStorage.getItem("accessToken"); // 저장된 토큰 가져오기
 
     useEffect(() => {
         if (questionText) {
@@ -38,7 +36,12 @@ export const DiaryEditorPage: React.FC = () => {
         }
 
         // 기타 태그 불러오기
-        fetch('http://localhost:8080/category/6/1') // 사용자 ID: 1로 고정
+        fetch('http://localhost:8080/category/6' , {
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            },
+            credentials: "include"
+        })
             .then(async response => {
                 if (response.status === 204) {
                     return []; // 내용 없을 때 빈 배열
@@ -98,8 +101,9 @@ export const DiaryEditorPage: React.FC = () => {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    // access 토큰
+                    "Authorization": `Bearer ${accessToken}`
                 },
+                credentials: "include",
                 body: JSON.stringify(requestData),
             });
 
@@ -157,7 +161,7 @@ export const DiaryEditorPage: React.FC = () => {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    // Access Token 추가 필요
+                    'Authorization': `Bearer ${accessToken}`
                 },
                 body: JSON.stringify(newTag), // newTag를 JSON 형식으로 변환하여 body에 추가
             })
@@ -244,7 +248,7 @@ export const DiaryEditorPage: React.FC = () => {
 
     return (
         <div className="diary-page">
-            <Header/>
+            <Header />
             <main className="main-content">
                 {isEditingTitle ? (
                     <input


### PR DESCRIPTION
## 📝 작업 내용

### **✨ 카드 타이틀 질문 기반 설정 및 수정 기능 추가**
- 카드 생성 시 질문 내용을 기반으로 타이틀이 자동 설정되도록 수정
- 카드의 타이틀 클릭 시 텍스트 입력 상태로 전환되어 수정 가능
- 기존 static 타이틀 구조에서 동적으로 변경 가능한 구조로 개선

### **🔐 Authorization 헤더에 access token 추가**
- 서버 요청 시 `Authorization` 헤더에 `localStorage`에서 access token을 포함하여 인증 처리
- '기타' 카테고리의 태그 데이터 불러오기, 일기 저장 요청 등에 사용됨
- 인증된 사용자만 요청 가능하도록 보안 처리 강화

### **🛠️ 라우팅 수정: `/editor/:questionText` 경로 추가**
- `EditorPage` 컴포넌트에 `questionText` 파라미터 전달 가능하도록 라우팅 수정
- URL에서 전달된 질문 텍스트를 기반으로 에디터 초기화 가능

### **🎨 스타일 수정: `DiartEditorPage.css`**
- `DiartEditorPage` 관련 CSS 일부 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
**제목 수정**
![image](https://github.com/user-attachments/assets/6320efa1-c868-4e06-8503-72ed563ebe1a)

## 💬 공유사항 to 리뷰어
- `/editor` 페이지로 라우팅 시 페이지 안 뜸!! `/editor/질문` 형식으로 이동해야 라우팅되므로 메일에서 `일기작성`으로 접속 권장

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).