### PR TITLE
feat: 월별 일기 조회 기능 및 메일 설정 저장 로직 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,8 @@ import SuccessPage from './pages/success/SuccessPage';
 import ListPage from './pages/diary/list/ListPage';
 import SettingPage from './pages/setting/MailSettingPage';
 import EditorPage from './pages/diary/diaryEditor/DiaryEditorPage';
+import DiaryDetailPage from './pages/diary/diaryDetail/DiaryDetailPage';
+
 
 function App() {
   return (

--- a/client/src/pages/diary/list/ListPage.css
+++ b/client/src/pages/diary/list/ListPage.css
@@ -18,6 +18,13 @@
   width: 100vw;
 }
 
+.webpage-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 중앙 정렬 */
+  width: 100%;
+}
+
 .username {
   font-weight: bold;
   color: #4a90e2;
@@ -51,7 +58,9 @@
   overflow-y: auto;
   padding-right: 0.5rem;
   margin-bottom: 2rem;
-  width: clamp(200px, 80vw, 600px);
+  width: clamp(200px, 80vw, 1000px);
+  align-items: center;
+  overflow: hidden; /* 스크롤 제거 */
 }
 
 /* 일기 항목 */
@@ -62,22 +71,39 @@
   background-color: #f1f1f1;
   border-radius: 10px;
   padding: clamp(1rem, 2vw, 1.5rem);
+  width: clamp(250px, 80vw, 900px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.diary-item:hover {
+  transform: translateY(-3px);
 }
 
 .date-tag {
   background-color: #e60023;
   color: white;
-  padding: clamp(0.3rem, 0.5vw, 0.5rem) clamp(0.8rem, 1vw, 1rem);
-  border-radius: 8px;
-  font-size: clamp(0.8rem, 1.2vw, 1rem);
-  margin-right: 1.5rem;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%; /* 동그랗게 */
+  font-size: 1rem;
+  margin-right: 1rem;
+  font-weight: bold;
 }
 
 .diary-title {
   flex-grow: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
   font-size: clamp(1rem, 2vw, 1.2rem);
+  font-weight: bold;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .write-button {

--- a/client/src/pages/header/Header.tsx
+++ b/client/src/pages/header/Header.tsx
@@ -1,37 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import './Header.css';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
+    const [token, setToken] = useState<string>('');
 
-        const handleLogout = async () => {
-            try {
-                const response = await fetch('/auth/logout', {
-                    method: 'POST',
-                    credentials: 'include', // 쿠키를 포함해 요청
-                });
+    // 쿠키에서 토큰을 읽는 함수
+    const getAccessTokenFromCookies = (): string => {
+        const name = 'accessToken=';
+        const decoded = decodeURIComponent(document.cookie);
+        return decoded
+            .split('; ')
+            .find((row) => row.startsWith(name))
+            ?.substring(name.length) ?? '';
+    };
 
-                if (response.ok) {
-                    // 로그아웃 성공 시 로그인 페이지로 이동
-                    navigate('/');
-                } else {
-                    console.error('로그아웃 실패');
-                }
-            } catch (error) {
-                console.error('로그아웃 중 오류 발생:', error);
+    // 마운트 시 토큰을 상태로 저장
+    useEffect(() => {
+        const accessToken = getAccessTokenFromCookies();
+        console.log('읽어온 accessToken:', accessToken); // 디버깅용
+        setToken(accessToken);
+    }, []);
+
+    const handleLogout = async () => {
+        if (!token) {
+            console.log('로그인 상태가 아닙니다.');
+            navigate('/'); // 또는 로그인 페이지 경로
+            return;
+        }
+
+        try {
+            const logoutRes = await fetch('http://localhost:8080/auth/logout', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`,
+                },
+                credentials: 'include',
+            });
+
+            if (!logoutRes.ok) {
+                const errorData = await logoutRes.json();
+                console.error('로그아웃 실패:', errorData);
+                alert('로그아웃에 실패했습니다.');
+                return;
             }
-        };
+
+            // 로그아웃 성공 처리
+            console.log('로그아웃 성공');
+            document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+            navigate('/');
+        } catch (error) {
+            console.error('로그아웃 처리 중 오류 발생:', error);
+            alert('로그아웃 처리 중 오류가 발생했습니다.');
+        }
+    };
 
     return (
         <header className="header">
             <div className="logo">하루 메일</div>
-                <nav className="nav">
-                    <Link to="/list">일기 목록</Link>
-                    <Link to="/search">일기 검색</Link>
-                    <Link to="/setting">설정</Link>
-                    <button onClick={handleLogout}>로그아웃</button>
-                </nav>
+            <nav className="nav">
+                <Link to="/list">일기 목록</Link>
+                <Link to="/search">일기 검색</Link>
+                <Link to="/setting">설정</Link>
+                <button onClick={handleLogout}>로그아웃</button>
+            </nav>
         </header>
     );
 };

--- a/client/src/pages/header/Header.tsx
+++ b/client/src/pages/header/Header.tsx
@@ -19,7 +19,6 @@ const Header: React.FC = () => {
     // 마운트 시 토큰을 상태로 저장
     useEffect(() => {
         const accessToken = getAccessTokenFromCookies();
-        console.log('읽어온 accessToken:', accessToken); // 디버깅용
         setToken(accessToken);
     }, []);
 

--- a/client/src/pages/setting/MailSettingPage.tsx
+++ b/client/src/pages/setting/MailSettingPage.tsx
@@ -1,10 +1,26 @@
-// MailSetting.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Header from '../header/Header'; // Header 컴포넌트 경로
 import './MailSettingPage.css';
 
 const MailSetting: React.FC = () => {
   const [selectedOption, setSelectedOption] = useState<string>('daily');
+  const [token, setToken] = useState<string>(''); // 토큰 상태 추가
+
+  // 쿠키에서 토큰을 읽는 함수
+  const getAccessTokenFromCookies = (): string => {
+    const name = 'accessToken=';
+    const decoded = decodeURIComponent(document.cookie);
+    return decoded
+      .split('; ')
+      .find((row) => row.startsWith(name))
+      ?.substring(name.length) ?? '';
+  };
+
+  // 마운트 시 토큰 상태로 저장
+  useEffect(() => {
+    const accessToken = getAccessTokenFromCookies();
+    setToken(accessToken);
+  }, []);
 
   const mailOptions = [
     { value: 'daily', label: '매일 받아 볼래요! (주 7회)' },
@@ -17,15 +33,42 @@ const MailSetting: React.FC = () => {
     setSelectedOption(e.target.value);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    alert(`설정이 저장되었습니다: ${selectedOption}`);
-    // TODO: 서버에 POST 요청 보내기
+
+    if (!token) {
+      console.log('로그인된 사용자가 아닙니다.');
+      alert('로그인 후 다시 시도해 주세요.');
+      return;
+    }
+
+    try {
+      const response = await fetch('http://localhost:8080/api/mail/settings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ selectedOption }),
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        console.error('설정 저장 실패:', errorData);
+        alert('설정 저장에 실패했습니다.');
+        return;
+      }
+      console.log(selectedOption)
+      alert(`설정이 저장되었습니다: ${selectedOption}`);
+    } catch (error) {
+      console.error('서버와의 통신 중 오류 발생:', error);
+      alert('서버와의 통신에 문제가 발생했습니다.');
+    }
   };
 
   return (
     <div className="webpage-layout">
-      <Header /> {/* 헤더 컴포넌트 사용 */}
+      <Header />
 
       <main className="mail-setting-main">
         <section className="mail-setting-content">


### PR DESCRIPTION
## 📝 작업 내용

- 월별 일기 목록 조회 기능 구현
  - 년도와 월 기준으로 서버에서 일기 목록을 불러오는 기능 추가
  - 이전/다음 월로 이동 시 새로운 데이터 요청 및 렌더링
- 메일 설정 저장 기능 구현
  - 쿠키에서 accessToken을 읽어와 상태로 저장
  - 로그인 상태 확인 후 서버에 메일 수신 설정 POST 요청
  - 설정 성공/실패에 따른 알림 처리
 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 월 변경 시 데이터 요청 타이밍과 리렌더링 타이밍이 괜찮은지 확인 
- 렌더링 시 로그인 되있는지 체크해야함..

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).