### PR TITLE
일기 목록 페이지 UI 수정

### DIFF
--- a/client/src/pages/diary/list/ListPage.css
+++ b/client/src/pages/diary/list/ListPage.css
@@ -21,44 +21,63 @@
 .webpage-container {
   display: flex;
   flex-direction: column;
-  align-items: center; /* 중앙 정렬 */
+  align-items: center;
   width: 100%;
+}
+
+.header-container h2 {
+  font-size: clamp(1.4rem, 3.2vw, 2.0rem);
+  color: #333;
+  text-align: center;
+  line-height: 1.4;
+  font-weight: normal;
+  margin-top: -2rem;
+  margin-bottom: 3rem;
 }
 
 .username {
   font-weight: bold;
-  color: #4a90e2;
+  color: inherit;
+  font-size: inherit;
 }
 
 .calendar-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: clamp(200px, 80vw, 600px);
-  margin: 2rem auto;
-  font-size: clamp(1rem, 3vw, 1.5rem);
+  width: clamp(250px, 80vw, 600px);
+  margin: 2rem auto 2.5rem auto;
+  font-size: clamp(1.2rem, 3.5vw, 1.8rem);
+  color: #333;
 }
 
 .arrow {
   background: none;
   border: none;
-  font-size: clamp(1.2rem, 4vw, 2rem);
+  font-size: clamp(1.5rem, 4.5vw, 2.2rem);
   cursor: pointer;
+  color: #333;
+  padding: 0 2rem;
+  transition: color 0.2s ease;
+}
+
+.arrow:hover {
+  color: #000;
 }
 
 .month-label {
-  font-size: clamp(1rem, 2.5vw, 1.3rem);
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
   font-weight: bold;
 }
 
 .diary-list {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 3rem;
   overflow-y: auto;
   padding-right: 0.5rem;
-  margin-bottom: 2rem;
-  width: clamp(200px, 80vw, 1000px);
+  margin-bottom: 4rem;
+  width: clamp(300px, 90vw, 1200px);
   align-items: center;
   overflow-y: auto;
 }
@@ -67,15 +86,14 @@
 .diary-item {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
   background-color: #f1f1f1;
-  border-radius: 20px;
-  padding: clamp(0.8rem, 1.5vw, 1.2rem);
-  width: clamp(280px, 85vw, 800px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  border-radius: 15px;
+  padding: clamp(0.3rem, 1.3vw, 0.7rem);
+  width: 100%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.3s ease;
-  gap: 1.2rem;
+  gap: clamp(1rem, 1.5vw, 1.8rem);
 }
 
 .diary-item:hover {
@@ -86,17 +104,23 @@
 .date-tag {
   background-color: #e60023;
   color: white;
-  width: 45px;
-  height: 45px;
-  min-width: 45px;
-  min-height: 45px;
   display: flex;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  font-size: 1.1rem;
-  font-weight: 600;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15); /* 살짝 그림자 */
+  font-weight: 700;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+  text-align: center;
+  line-height: 1;
+  width: clamp(30px, 10vw, 45px); /* 최소 40px, 뷰포트 너비의 11%, 최대 60px */
+  height: clamp(30px, 10vw, 45px); /* 원형 유지를 위해 width와 동일하게 설정 */
+}
+
+/* 날짜 숫자 */
+.date-tag .date-number {
+  font-size: clamp(1rem, 3vw, 1.5rem); /* 부모 크기에 맞춰 폰트 크기 조정 */
+  line-height: 1;
 }
 
 .diary-title {
@@ -110,22 +134,23 @@
   padding-right: 0.5rem;
 }
 
-
 .write-button {
   background-color: #e60023;
   color: white;
-  padding: clamp(0.8rem, 1.5vw, 1.2rem) clamp(1.5rem, 2.5vw, 2rem);
   border: none;
+  font-weight: bold;
   border-radius: 999px;
-  font-size: clamp(1.2rem, 2vw, 1.4rem);
   cursor: pointer;
-  transition: background-color 0.3s, transform 0.3s;
-  width: clamp(180px, 40vw, 280px);
-  height: clamp(45px, 10vw, 65px);
-  margin-top: 3rem;
-  margin-bottom: 5%;
+  transition: background-color 0.3s, transform 0.3s, box-shadow 0.3s;
+  margin-top: 3.5rem;
+  margin-bottom: 6%;
   margin-left: auto;
   margin-right: auto;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  font-size: 18px;
+  padding: 0.75rem 1.5rem;
+  width: clamp(180px, 45vw, 250px);
+  height: clamp(40px, 15vw, 55px);
 }
 
 .write-button:hover,

--- a/client/src/pages/diary/list/ListPage.tsx
+++ b/client/src/pages/diary/list/ListPage.tsx
@@ -22,51 +22,16 @@ const ListPage: React.FC = () => {
   const [currentYear, setCurrentYear] = useState<number>(0);
   const [currentMonth, setCurrentMonth] = useState<number>(0);
 
-  const getAccessTokenFromCookies = (): string => {
-    const name = 'accessToken=';
-    const decoded = decodeURIComponent(document.cookie);
-    return (
-      decoded
-        .split('; ')
-        .find(row => row.startsWith(name))
-        ?.substring(name.length) ?? ''
-    );
-  };
-
-  // 이전 달
-  const handlePrevMonth = () => {
-    setCurrentMonth(prevMonth => {
-      if (prevMonth === 1) {
-        setCurrentYear(prevYear => prevYear - 1);
-        return 12;
-      } else {
-        return prevMonth - 1;
-      }
-    });
-  };
-
-  // 다음 달
-  const handleNextMonth = () => {
-    setCurrentMonth(prevMonth => {
-      if (prevMonth === 12) {
-        setCurrentYear(prevYear => prevYear + 1);
-        return 1;
-      } else {
-        return prevMonth + 1;
-      }
-    });
-  };
-
+  // 현재 월을 기준으로 연도와 월 초기화
   useEffect(() => {
     const now = new Date();
     setCurrentYear(now.getFullYear());
     setCurrentMonth(now.getMonth() + 1); // 월은 0부터 시작하므로 +1 필요
   }, []);
 
+  // API 호출 및 데이터 로딩
   useEffect(() => {
     async function fetchData() {
-      const token = localStorage.getItem('accessToken');
-
       try {
         setLoading(true);
         // 1) 사용자 정보 호출
@@ -75,11 +40,10 @@ const ListPage: React.FC = () => {
           headers: {
             'Content-Type': 'application/json',
           },
-          credentials: 'include',
+          credentials: 'include', // 쿠키 자동 전송
         });
 
         if (!userRes.ok) {
-          // 인증 실패(401) 또는 기타 오류 발생 시 로그인 페이지로 리다이렉트
           console.error('사용자 정보 호출 실패:', userRes.status, userRes.statusText);
           alert('로그인이 필요하거나 세션이 만료되었습니다. 다시 로그인해주세요.');
           navigate('/');
@@ -96,12 +60,11 @@ const ListPage: React.FC = () => {
             headers: {
               'Content-Type': 'application/json',
             },
-            credentials: 'include',
+            credentials: 'include', // 쿠키 자동 전송
           }
         );
 
         if (!diaryRes.ok) {
-          // 일기 목록 호출 실패 시 로그인 페이지로 리다이렉트 (인증 문제로 가정)
           console.error('일기 목록 호출 실패:', diaryRes.status, diaryRes.statusText);
           alert('일기 목록을 불러오는 데 실패했습니다. 다시 로그인해주세요.');
           navigate('/');
@@ -109,10 +72,8 @@ const ListPage: React.FC = () => {
         }
         const diaryData: DiaryItem[] = await diaryRes.json();
 
-        console.log('Received Diary Data:', diaryData);
         setDiaries(diaryData);
       } catch (error) {
-        // 네트워크 오류 등 예상치 못한 오류 발생 시
         console.error('API 호출 중 오류 발생:', error);
         alert('페이지 로딩 중 오류가 발생했습니다. 다시 시도해주세요.');
         navigate('/');
@@ -123,9 +84,33 @@ const ListPage: React.FC = () => {
 
     // currentYear와 currentMonth가 유효한 값일 때만 fetchData 호출
     if (currentYear !== 0 && currentMonth !== 0) {
-        fetchData();
+      fetchData();
     }
-  }, [currentYear, currentMonth, navigate]);
+  }, [currentYear, currentMonth, navigate]); // currentYear, currentMonth 변경 시 fetchData 재실행
+
+  // 이전 달로 이동
+  const handlePrevMonth = () => {
+    setCurrentMonth(prevMonth => {
+      if (prevMonth === 1) {
+        setCurrentYear(prevYear => prevYear - 1);
+        return 12;
+      } else {
+        return prevMonth - 1;
+      }
+    });
+  };
+
+  // 다음 달로 이동
+  const handleNextMonth = () => {
+    setCurrentMonth(prevMonth => {
+      if (prevMonth === 12) {
+        setCurrentYear(prevYear => prevYear + 1);
+        return 1;
+      } else {
+        return prevMonth + 1;
+      }
+    });
+  };
 
   if (loading) {
     return <div className="loading">로딩 중...</div>;
@@ -133,10 +118,11 @@ const ListPage: React.FC = () => {
 
   return (
     <div className="webpage-layout">
-      <Header />
+      <Header /> {/* Header는 이미 디자인되어 있다고 가정 */}
 
       <main className="webpage-container">
         <div className="header-container">
+          {/* 이미지에 맞춰 username이 다른 색상이나 줄바꿈 없이 한 문장으로 */}
           <h2>
             <span className="username">{user?.username ?? '사용자'}</span> 님이 작성하신 일기 목록이에요!
           </h2>
@@ -162,7 +148,10 @@ const ListPage: React.FC = () => {
                   className="diary-item"
                   onClick={() => navigate(`/diary/${diary.id}`)}
                 >
-                  <div className="date-tag">{date.getDate()}일</div>
+                  <div className="date-tag">
+                    <span className="date-number">{date.getDate()}</span>
+                    <span className="date-suffix">일</span>
+                  </div>
                   <div className="diary-title">{diary.title}</div>
                   <div className="arrow">→</div>
                 </div>

--- a/client/src/pages/home/HomePage.css
+++ b/client/src/pages/home/HomePage.css
@@ -1,5 +1,3 @@
-/* HomePage.css */
-
 /* 웹페이지 레이아웃 전체 */
 .webpage-layout {
   display: flex;
@@ -28,18 +26,14 @@
 }
 
 .homepage-logo {
-  font-size: 1.5rem; /* rem 단위로 변경 (데스크톱 기본) */
-  font-weight: bold;
-  color: #333;
-  cursor: pointer;
-  user-select: none;
-  text-decoration: none; /* 링크 밑줄 제거 */
+    font-size: 1.7rem;
+    font-weight: bold;
+    color: #333;
 }
 
 .homepage-logo:hover {
-  opacity: 0.8;
-  transition: 0.2s;
-  color: #333;
+    color: #eb1c24;
+    transition: color 0.2s ease-in-out;
 }
 
 .login-button {


### PR DESCRIPTION
## 📝 작업 내용

주요 변경사항:
- **사용자 이름 제목 스타일 조정:**
  - 사용자 이름만 볼드체로 표시하고 나머지 제목 텍스트는 일반 굵기로 설정.
  - `.header-container h2`로 선택자 범위를 명확히 하여 홈 화면 등 다른 페이지에 스타일이 영향을 미치지 않도록 수정.
  - 제목의 상하 여백을 조정하여 배치 개선.
- **모바일 환경 측면 여백 확보:**
  - `.diary-list` 및 `.calendar-header`의 `width` clamp 값에 `vw` 단위를 조정하여 작은 화면에서 콘텐츠 좌우 여백 증가.
- **'일기 작성하기' 버튼 크기 및 폰트 통일:**
  - 버튼의 전체적인 크기(padding, width, height)를 줄여 더 간결하게 변경.
  - '로그아웃' 버튼과 동일한 `18px` 폰트 크기 적용.
  - 작은 화면에서 버튼 텍스트가 줄바꿈되는 현상을 방지하기 위해 `white-space: nowrap` 추가 및 최소 너비 조정.
- **날짜 태그(date-tag) 반응형 크기 적용:**
  - `date-tag`의 `width`, `height`, `min-width`, `min-height`에 `clamp()` 함수를 사용하여 카드 크기에 맞춰 동적으로 조절되도록 구현.
  - 내부 날짜 숫자 및 '일' 텍스트의 폰트 크기도 함께 반응형으로 조정.
  
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
**전체 화면 시**
![image](https://github.com/user-attachments/assets/c773fcf1-6b22-48b5-aad5-bb7018574d1d)

**모바일 화면 시**
![image](https://github.com/user-attachments/assets/4d05e43d-0ce4-4758-befa-d13063fcbd06)



## 💬 공유사항 to 리뷰어
- 수정해야할 부분이 있다면 알려주세여

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).