### PR TITLE
HomePage 및 태그 검색 UI 수정

### DIFF
--- a/client/src/pages/diary/list/ListPage.css
+++ b/client/src/pages/diary/list/ListPage.css
@@ -26,13 +26,13 @@
 }
 
 .header-container h2 {
-  font-size: clamp(1.4rem, 3.2vw, 2.0rem);
+  font-size: clamp(2.2rem, 4vw, 3rem);
   color: #333;
   text-align: center;
   line-height: 1.4;
   font-weight: normal;
   margin-top: -2rem;
-  margin-bottom: 3rem;
+  margin-bottom: 5rem;
 }
 
 .username {
@@ -57,7 +57,7 @@
   font-size: clamp(1.5rem, 4.5vw, 2.2rem);
   cursor: pointer;
   color: #333;
-  padding: 0 2rem;
+  padding: 0 3rem;
   transition: color 0.2s ease;
 }
 
@@ -66,7 +66,7 @@
 }
 
 .month-label {
-  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-size: clamp(2rem, 4vw, 3rem);
   font-weight: bold;
 }
 
@@ -88,7 +88,7 @@
   align-items: center;
   background-color: #f1f1f1;
   border-radius: 15px;
-  padding: clamp(0.3rem, 1.3vw, 0.7rem);
+  padding: clamp(1rem, 1.3vw, 1rem);
   width: 100%;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   cursor: pointer;
@@ -113,25 +113,21 @@
   flex-shrink: 0;
   text-align: center;
   line-height: 1;
-  width: clamp(30px, 10vw, 45px); /* 최소 40px, 뷰포트 너비의 11%, 최대 60px */
-  height: clamp(30px, 10vw, 45px); /* 원형 유지를 위해 width와 동일하게 설정 */
-}
-
-/* 날짜 숫자 */
-.date-tag .date-number {
-  font-size: clamp(1rem, 3vw, 1.5rem); /* 부모 크기에 맞춰 폰트 크기 조정 */
-  line-height: 1;
+  width: clamp(30px, 10vw, 45px);
+  height: clamp(30px, 10vw, 45px);
+  font-size: clamp(1.5rem, 1.5vw, 1.5rem);
 }
 
 .diary-title {
   flex-grow: 1;
-  font-size: clamp(1.1rem, 2.2vw, 1.3rem);
+  font-size: clamp(1.8rem, 2vw, 2rem);
   font-weight: 600;
   color: #333;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding-right: 0.5rem;
+  padding-right: 0.3rem;
+  padding-left: 2rem;
 }
 
 .write-button {
@@ -167,4 +163,8 @@
   font-size: 1.5rem;
   color: #e60023;
   font-weight: bold;
+}
+
+.empty{
+  font-size: clamp(1.8rem, 2vw, 2rem);
 }

--- a/client/src/pages/diary/search/SearchPage.css
+++ b/client/src/pages/diary/search/SearchPage.css
@@ -45,14 +45,14 @@ html {
 
 /* 카테고리 버튼 기본 스타일 */
 .category {
-    padding: clamp(0.8rem, 1.3vw, 1.5rem) clamp(0.5rem, 1vw, 1.5rem);
+    padding: clamp(0.4rem, 1.3vw, 1.5rem) clamp(0.2rem, 0.5vw, 1.5rem);
     border-radius: 0;
     background-color: transparent;
     color: #bababa;
     border: none;
     font-weight: bold;
     cursor: pointer;
-    font-size: clamp(1.6rem, 2.1vw, 2rem);
+    font-size: clamp(1.3rem, 2.1vw, 2rem);
     outline: none;
     flex-shrink: 0;
     white-space: nowrap;
@@ -120,7 +120,7 @@ html {
     display: flex;
     align-items: center;
     background-color: #f2f2f2;
-    padding: clamp(2rem, 3vw, 3rem);
+    padding: clamp(0.7rem, 1.7vw, 1.7rem);
     border-radius: clamp(0.8rem, 1.2vw, 1.2rem);
     margin: 0 clamp(4rem, 6vw, 6rem) clamp(2rem, 3vw, 3rem);
     animation: fadeSlideIn 0.5s ease forwards;
@@ -132,8 +132,8 @@ html {
 .date-box {
     background-color: #E53935;
     color: white;
-    width: clamp(5.5rem, 6.5vw, 6.5rem);
-    height: clamp(5.5rem, 6.5vw, 6.5rem);
+    width: clamp(5rem, 6vw, 6rem);
+    height: clamp(5rem, 6vw, 6rem);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -145,7 +145,14 @@ html {
 
 /* 질문 텍스트 */
 .question-text {
-    font-size: clamp(1.8rem, 2.2vw, 2.2rem);
+  flex-grow: 1;
+  font-size: clamp(2rem, 2vw, 2rem);
+  font-weight: 600;
+  color: #333;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 0.5rem;
 }
 
 /* 페이드 인 슬라이드 애니메이션 */
@@ -184,6 +191,7 @@ html {
     font-size: clamp(2rem, 3vw, 3rem);
     font-weight: bold;
     margin-bottom: clamp(0.8rem, 1vw, 1rem);
+    padding: 0 clamp(4rem, 6vw, 6rem);
 }
 
 /* 구분선 */
@@ -191,6 +199,8 @@ hr {
     border: none;
     border-top: 0.1rem solid #ccc;
     margin-bottom: clamp(1.5rem, 1.8vw, 1.8rem);
+    margin-left: clamp(4rem, 6vw, 6rem);
+    margin-right: clamp(4rem, 6vw, 6rem);
 }
 
 /* 선택된 태그를 보여주는 컨테이너 */

--- a/client/src/pages/diary/search/SearchPage.tsx
+++ b/client/src/pages/diary/search/SearchPage.tsx
@@ -3,21 +3,20 @@ import { useState } from "react";
 import Header from '../../header/Header.tsx';
 import './SearchPage.css';
 import { CategoryTags, initialCategoryTags } from "../diaryEditor/TagData.ts";
-import {handleRemoveTag, handleTagClick} from "../diaryEditor/TagHandler.ts";
+import {handleRemoveTag} from "../diaryEditor/TagHandler.ts"; // Keep handleRemoveTag as is
 import { useNavigate } from 'react-router-dom';
 
 const SearchPage: React.FC = () => {
     const navigate = useNavigate();
     const categories = ["기분", "생활 & 경험", "취미", "특별한 순간", "날씨", "기타"];
-    const [selectedCategory, setSelectedCategory] = useState<string>(''); // 선택된 카테고리
-    const [selectedTags, setSelectedTags] = useState<{ id: number; emoji: string; label: string }[]>([]); // 선택된 태그 / 혹시 오류나면 id: number; 지우기
-    const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]); // 태그 id만 저장
-    const accessToken = localStorage.getItem("accessToken"); // 저장된 토큰 가져오기
-    const [categoryTags, setCategoryTags] = useState<CategoryTags>(initialCategoryTags); // 카테고리 리스트
-    const [searchResults, setSearchResults] = useState<{ diaryId: number; title: string; date: string }[]>([]); // 검색 결과
+    const [selectedCategory, setSelectedCategory] = useState<string>('');
+    const [selectedTags, setSelectedTags] = useState<{ id: number; emoji: string; label: string }[]>([]);
+    const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+    const accessToken = localStorage.getItem("accessToken");
+    const [categoryTags, setCategoryTags] = useState<CategoryTags>(initialCategoryTags);
+    const [searchResults, setSearchResults] = useState<{ diaryId: number; title: string; date: string }[]>([]);
 
     useEffect(() => {
-        // 기타 태그 불러오기
         fetch('http://localhost:8080/api/category/6' , {
             headers: {
                 'Authorization': `Bearer ${accessToken}`
@@ -26,7 +25,7 @@ const SearchPage: React.FC = () => {
         })
             .then(async response => {
                 if (response.status === 204) {
-                    return []; // 내용 없을 때 빈 배열
+                    return [];
                 } else if (!response.ok) {
                     throw new Error('서버 오류');
                 }
@@ -37,7 +36,7 @@ const SearchPage: React.FC = () => {
 
                 const newTag = data.map((tag: any) => ({
                     id: tag.tagId,
-                    emoji: '🏷️', // 임시
+                    emoji: '🏷️',
                     label: tag.name
                 }));
 
@@ -74,11 +73,31 @@ const SearchPage: React.FC = () => {
             })
             .then(data => {
                 console.log("검색 결과:", data);
-                setSearchResults(data); // 검색 결과 상태에 저장
+                setSearchResults(data);
             })
             .catch(error => {
                 console.error("검색 오류:", error);
             });
+    };
+
+    // Modified handleTagClick function
+    const handleTagClick = (tag: { id: number; emoji: string; label: string }) => {
+        // Check if the tag is already selected
+        const isSelected = selectedTagIds.includes(tag.id);
+
+        if (isSelected) {
+            // If already selected, remove it
+            setSelectedTags(prev => prev.filter(t => t.id !== tag.id));
+            setSelectedTagIds(prev => prev.filter(id => id !== tag.id));
+        } else {
+            // If not selected, check the limit before adding
+            if (selectedTags.length < 5) {
+                setSelectedTags(prev => [...prev, tag]);
+                setSelectedTagIds(prev => [...prev, tag.id]);
+            } else {
+                alert("태그는 5개까지만 선택할 수 있습니다.");
+            }
+        }
     };
 
     return (
@@ -118,15 +137,13 @@ const SearchPage: React.FC = () => {
                     ))}
                 </div>
 
-                {/* 선택된 카테고리에 해당하는 태그 표시 */}
                 {selectedCategory && (
                     <div className="tag-wrapper">
                         {categoryTags[selectedCategory]?.map((tag) => (
                             <span
                                 key={tag.id}
-                                // 여기를 수정합니다.
                                 className={`tag-button ${selectedTagIds.includes(tag.id) ? "active" : ""}`}
-                                onClick={() => handleTagClick(tag, selectedTags, selectedTagIds, setSelectedTags, setSelectedTagIds)}
+                                onClick={() => handleTagClick(tag)} // Call the local handleTagClick
                                 data-id={tag.id}
                             >
                                 {tag.emoji} {tag.label}

--- a/client/src/pages/header/Header.tsx
+++ b/client/src/pages/header/Header.tsx
@@ -8,7 +8,7 @@ const Header: React.FC = () => {
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
     const navRef = useRef<HTMLDivElement>(null);
-    const headerRef = useRef<HTMLDivElement>(null);
+    const headerRef = useRef<HTMLDivElement>(null); // headerRef는 현재 사용되지 않지만, 외부 클릭 로직에 포함되어 있어 남겨둡니다.
 
     // 쿠키에서 토큰을 읽는 함수
     const getAccessTokenFromCookies = (): string => {
@@ -30,13 +30,12 @@ const Header: React.FC = () => {
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
             const target = event.target as Node;
-            // 메뉴가 열려 있고, nav나 header 영역 밖을 클릭했을 때만 닫음
+            // 메뉴가 열려 있고, nav 영역 밖을 클릭했을 때 닫음
+            // headerRef는 햄버거 메뉴 자체를 포함하므로, 이 조건에서 제외하는 것이 일반적입니다.
             if (
                 menuOpen &&
                 navRef.current &&
-                !navRef.current.contains(target) &&
-                headerRef.current &&
-                !headerRef.current.contains(target)
+                !navRef.current.contains(target)
             ) {
                 setMenuOpen(false);
             }
@@ -51,7 +50,9 @@ const Header: React.FC = () => {
     const handleLogout = async () => {
         if (!token) {
             console.log('로그인 상태가 아닙니다.');
-            navigate('/'); // 또는 로그인 페이지 경로
+            // 사용자가 이미 로그아웃 상태라면 알림 후 홈으로 이동
+            alert('이미 로그아웃되었습니다.'); // 추가: 이미 로그아웃된 경우 안내
+            navigate('/');
             return;
         }
 
@@ -75,6 +76,8 @@ const Header: React.FC = () => {
             // 로그아웃 성공 처리
             console.log('로그아웃 성공');
             document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+            setToken(''); // 토큰 상태 초기화
+            alert('로그아웃되었습니다.'); // 추가: 로그아웃 성공 알림
             navigate('/');
         } catch (error) {
             console.error('로그아웃 처리 중 오류 발생:', error);
@@ -102,7 +105,13 @@ const Header: React.FC = () => {
                 <Link to="/list">일기 목록</Link>
                 <Link to="/search">일기 검색</Link>
                 <Link to="/setting">설정</Link>
-                <button className="logout-button" onClick={handleLogout} id="logout-btn">로그아웃</button>
+                {/* 토큰이 있을 때만 로그아웃 버튼을 표시하도록 조건부 렌더링 */}
+                {token ? (
+                    <button className="logout-button" onClick={handleLogout} id="logout-btn">로그아웃</button>
+                ) : (
+                    // 토큰이 없을 때 로그인 버튼을 표시 (선택 사항)
+                    <button className="login-button" onClick={() => navigate('/login')}>로그인</button> // '로그인' 페이지 경로에 맞게 수정
+                )}
             </nav>
 
             {menuOpen && <div className="overlay" onClick={() => setMenuOpen(false)} />}

--- a/client/src/pages/home/HomePage.css
+++ b/client/src/pages/home/HomePage.css
@@ -101,12 +101,13 @@ html {
 .subscribe-button {
   background-color: #e53935;
   color: white;
-  padding: 0.75rem 1.5rem;
+  /* 패딩과 폰트 크기 조절 */
+  padding: 1.2rem 2.5rem; /* 더 큰 버튼을 위해 패딩 증가 */
   border-radius: 9999px;
   border: none;
   font-weight: bold;
   /* 1rem -> 1.6rem으로 조정 (약 16px) */
-  font-size: 1.6rem;
+  font-size: 1.8rem; /* 폰트 크기 증가 */
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -165,9 +166,44 @@ html {
 }
 
 .modal-content h2 {
-  /* 1.8rem -> 2.8rem으로 조정 (약 28px) */
   font-size: 2.8rem;
   font-weight: bold;
+  margin-bottom: 1.5rem;
+}
+
+/* 동의 체크박스 텍스트 */
+.agree-checkbox {
+  display: flex;
+  align-items: center;
+  margin-top: 2rem;
+  margin-bottom: 1.3rem;
+  font-size: 1.6rem;
+}
+
+.agree-checkbox input[type="checkbox"] {
+  width: 1.8rem;
+  height: 1.8rem;
+  margin-right: 0.8rem;
+}
+
+.agree-checkbox span {
+  font-size: 1.3rem;
+  color: #555;
+  line-height: 1.4;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  color: #888;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0.5rem;
+  font-size: 1.5rem;
+}
+
+.modal-content p {
+  font-size: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
@@ -183,6 +219,7 @@ html {
   margin-bottom: 2rem;
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.3s ease;
+  font-size: 15px;
 }
 
 .google-login:hover {
@@ -196,10 +233,11 @@ html {
   color: #666;
   border: none;
   opacity: 0.6;
+  outline: none;
+  box-shadow: none;
 }
 
 .warning-text {
-  /* 0.85rem -> 1.3rem으로 조정 (약 13px) */
   color: red;
   font-size: 1.3rem;
   margin-top: 0.5rem;
@@ -396,7 +434,8 @@ html {
   }
   .subscribe-button {
     /* 1.2rem -> 1.9rem으로 조정 (10px 기준 19px) */
-    font-size: 1.9rem;
+    font-size: 2.4rem; /* 구독 버튼 폰트 크기 대폭 증가 */
+    padding: 1.5rem 3rem; /* 구독 버튼 패딩 대폭 증가 */
   }
   .scroll-section-title {
     /* 2.6rem -> 4.1rem으로 조정 (10px 기준 41px) */
@@ -521,6 +560,9 @@ html {
     /* rem 값 증가 */
     font-size: 1.8rem;
     padding: 0.8rem 2rem;
+    /* 중앙 정렬을 위한 추가 */
+    margin: 0 auto;
+    align-self: center;
   }
   .image-section {
     justify-content: center;
@@ -600,8 +642,11 @@ html {
   }
   .subscribe-button {
     /* rem 값 증가 */
-    font-size: clamp(1.4rem, 4.5vw, 1.9rem);
-    padding: 0.7rem 1.8rem;
+    font-size: clamp(1.6rem, 5vw, 2.2rem); /* 구독 버튼 크기 증가 */
+    padding: 0.8rem 2rem; /* 패딩 조정 */
+    /* 중앙 정렬을 위한 추가 */
+    margin: 0 auto;
+    align-self: center;
   }
   .main-image {
     max-width: 80%;
@@ -650,12 +695,12 @@ html {
   }
   .subscribe-button {
     /* rem 값 증가 */
-    font-size: clamp(1.3rem, 5.5vw, 1.8rem);
-    padding: 0.7rem 1.8rem;
+    font-size: clamp(1.5rem, 6.5vw, 2rem); /* 구독 버튼 크기 증가 */
+    padding: 0.8rem 2rem; /* 패딩 조정 */
     margin: 0 auto;
-    justify-content: center;
-    align-self: center;
-    width: fit-content;
+    justify-content: center; /* flex item 내부 내용 중앙 정렬 */
+    align-self: center; /* flex container 내에서 자신을 중앙 정렬 */
+    width: fit-content; /* 내용에 맞춰 너비 조정 */
   }
   .scroll-section-title {
     /* rem 값 증가 */


### PR DESCRIPTION
## 📝 작업 내용
**태그 검색 시 최대 5개까지 추가되도록 수정**
- 태그 입력 필드에서 사용자가 태그를 추가할 때, 이미 추가된 태그의 수가 5개에 도달하면 더 이상 새 태그를 추가할 수 없도록 제한
- 검색 창에서 태그 길이가 넘어가는 경우 PC 환경에서 스크롤 바의 필요성 제거
- 모바일의 경우 필요할 수 있으므로 남겨는 두었음..

**HomePage 구독 모달 창 글씨 크기 수정**
- 닫기 버튼: close-button 클래스의 글씨 크기 증가
- 메일 수신 빈도 안내 문구: `<p>` 태그에 modal-description 클래스를 추가하여 글씨 크기 증가

**로그아웃 성공 알림 및 버튼 조건부 렌더링**
- 로그아웃 성공 알림: 로그아웃 API 호출이 성공적으로 완료되면 alert() 메시지를 통해 "로그아웃되었습니다."라는 알림이 뜸
- 로그아웃 상태 안내: 이미 로그아웃된 상태에서 로그아웃 버튼을 클릭할 경우 "이미 로그아웃되었습니다."라는 알림이 표시
- 버튼 조건부 렌더링: 사용자의 accessToken 유무에 따라 헤더에 '로그아웃' 버튼 또는 '로그인' 버튼이 동적으로 렌더링되도록 수정
- 외부 클릭 로직 개선: 햄버거 메뉴가 열려 있을 때 외부 클릭 시 메뉴가 닫히는 로직에서 헤더 영역을 제외하여, 햄버거 아이콘 클릭 시 메뉴가 즉시 닫히지 않고 토글되도록 정상화

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
**일기 검색**
![image](https://github.com/user-attachments/assets/9630f849-827c-4396-b185-19078c478475)


**일기 목록**
![image](https://github.com/user-attachments/assets/5c30fe49-d09c-402b-8a7f-0c8cb05394f6)

**구독 모달 창**
![image](https://github.com/user-attachments/assets/b374a18d-9ea3-454b-b2cc-d68369e2f1e9)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).