### PR TITLE
fix: 이메일 확인 API 요청 시 Refresh Token 없이 plainApiInstance 사용하도록 수정

### DIFF
--- a/client/src/pages/home/HomePage.tsx
+++ b/client/src/pages/home/HomePage.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import './HomePage.css';
 import apiClient from '../../utils/axiosInstance'; // ⭐ axiosInstance 임포트 경로 확인!
+import plainApiClient from '../../utils/plainApiClient'; // ⭐ axiosInstance 임포트 경로 확인!
+
 
 const HomePage: React.FC = () => {
   // ⭐ 구독 모달 관련 상태
@@ -164,7 +166,7 @@ const HomePage: React.FC = () => {
 
     try {
       // ⭐ 백엔드로 보낼 때도 loginEmail 사용
-      const response = await apiClient.get(`/api/auth/verify?email=${encodeURIComponent(loginEmail)}`);
+      const response = await plainApiClient.get(`/api/auth/verify?email=${encodeURIComponent(loginEmail)}`);
 
       if (response.status === 200 && response.data.status === 'verified') {
         setIsEmailVerified(true); // ⭐ 이메일 확인 성공 (구독자)

--- a/client/src/utils/plainApiClient.ts
+++ b/client/src/utils/plainApiClient.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const plainApiClient = axios.create({
+  baseURL: 'http://localhost:8080',
+  // 토큰 인터셉터 없음
+});
+
+export default plainApiClient;


### PR DESCRIPTION
## 📝 작업 내용

- Refresh Token 이 없으면 로그인 / 구독을 하기 위한 조회 요청을 못 보내는 문제 발생
- 별도 axios 인스턴스 생성 후 로그인 이메일 확인 요청 부분 수정
- 이메일 존재 확인 API 호출 시 인증 토큰 없이 요청하도록 plainApiInstance로 분리 및 적용

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved email verification process by using a dedicated HTTP client for certain API requests. 

- **Chores**
  - Introduced a new simple HTTP client for specific backend communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->